### PR TITLE
start the public_network if needed

### DIFF
--- a/virtualizor.py
+++ b/virtualizor.py
@@ -120,6 +120,9 @@ class Hypervisor(object):
             self.conn.networkCreateXML(pub_net.dump_libvirt_xml())
         self.public_net = self.conn.networkLookupByName(
             conf.public_network)
+        self.public_net.setAutostart(True)
+        if not self.public_net.isActive():
+            self.public_net.create()
 
         net_definitions = {("%s_sps" % conf.prefix): {}}
         for netname in net_definitions:


### PR DESCRIPTION
The conn.networkCreateXML will just define the network. We still need to
start it.
