### PR TITLE
virtualize.sh: initialize $tempest variable

### DIFF
--- a/virtualize.sh
+++ b/virtualize.sh
@@ -29,6 +29,7 @@ routerip=""
 installserverip=""
 virthost="localhost"
 platform="virt_platform.yaml"
+tempest=""
 
 ### Handler Functions
 


### PR DESCRIPTION
Initialize $tempest variable to avoid the following error:

```
tempest: unbound variable
```
