### PR TITLE
Revert "Adding nested capacity to VM"

### DIFF
--- a/templates/host.py
+++ b/templates/host.py
@@ -22,8 +22,6 @@ HOST = """
   <memory unit='KiB'>{{ memory }}</memory>
   <currentmemory unit='KiB'>{{ memory }}</currentmemory>
   <vcpu>{{ ncpus }}</vcpu>
-  <cpu mode='host-passthrough'>
-  </cpu>
   <os>
     <smbios mode='sysinfo'/>
     <type arch='x86_64' machine='pc'>hvm</type>


### PR DESCRIPTION
This reverts commit f7f36d5c59ec58bd4e3a65257194cef82bb39a72.

The use of cpu mode=passthrough breaks the internal snapshot support.
The problem is fixed with the 1.2.11 release of libvirt.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1030793
