### PR TITLE
functions: snapshot restore: restart mongod

### DIFF
--- a/common/infra-virt.function
+++ b/common/infra-virt.function
@@ -136,6 +136,15 @@ snapshot_restore() {
             # TODO(Gonéri): Is that really needed?
             ssh $SSHOPTS root@os-ci-test\${id} killall epmd || true
         done
+        for id in 12 11 10; do
+            (
+            while ! ssh $SSHOPTS root@os-ci-test\${id} systemctl status mongod.service|grep running; do
+                ssh $SSHOPTS root@os-ci-test\${id} systemctl restart mongod.service
+                sleep 5
+            done
+            exit 0
+            )&
+        done
         while true; do
             for id in 10 11 12; do
             (


### PR DESCRIPTION
Ensure we restart mongodb once the cluster has been restored.
During the snapshot, node 12 is the last running node, so we
reverse the order of the loop to get node 12 running first.
