### PR TITLE
virtualize.sh: use ORIG to source functions

### DIFF
--- a/virtualize.sh
+++ b/virtualize.sh
@@ -17,7 +17,7 @@
 # under the License.
 
 ORIG=$(cd $(dirname $0); pwd)
-source common/infra-virt.function
+source ${ORIG}/common/infra-virt.function
 
 ### virtualize.sh specific functions
 


### PR DESCRIPTION
Use the $ORIG variable to know the location of the infra-virt.function
file.
