### PR TITLE
functions: snapshot restore: restart mongod

### DIFF
--- a/common/infra-virt.function
+++ b/common/infra-virt.function
@@ -158,6 +158,19 @@ snapshot_restore() {
     done
 "
 
+    ssh $SSHOPTS root@$installserverip "
+        set -eux
+
+        while true; do
+            sleep 1
+            for id in 12 11 10; do
+                ssh $SSHOPTS root@os-ci-test\${id} systemctl status mongod.service|grep 'Active: active' && continue
+                ssh $SSHOPTS root@os-ci-test\${id} systemctl start mongod.service || continue 2
+            done
+            break
+        done"
+
+
 }
 
 snapshot_exists() {


### PR DESCRIPTION
Ensure we restart mongodb once the cluster has been restored.
During the snapshot, node 12 is the last running node, so we
reverse the order of the loop to get node 12 running first.
