### PR TITLE
Ensure LOG_DIR exists

### DIFF
--- a/common/infra-virt.function
+++ b/common/infra-virt.function
@@ -34,6 +34,8 @@ tempest=""
 # Default values if not set by user env
 TIMEOUT_ITERATION=${TIMEOUT_ITERATION:-"150"}
 LOG_DIR=${LOG_DIR:-"$(pwd)/logs"}
+[ -d ${LOG_DIR} ] || mkdir -p ${LOG_DIR}
+
 SSH_AUTH_SOCK=${SSH_AUTH_SOCK:-""}
 
 SSHOPTS="-oBatchMode=yes -oCheckHostIP=no -oHashKnownHosts=no  -oStrictHostKeyChecking=no -oPreferredAuthentications=publickey  -oChallengeResponseAuthentication=no -oKbdInteractiveDevices=no -oUserKnownHostsFile=/dev/null -oControlPath=~/.ssh/control-%r@%h:%p -oControlMaster=auto -oControlPersist=30"


### PR DESCRIPTION
This commit ensure that the directory pointed by
LOG_DIR exists before dumping the elasticsearch DB.
