### PR TITLE
use metadata to find the machines

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -107,6 +107,8 @@ def collect(config_path, qcow, sps_version, images_url):
     img = "%s-%s.img.qcow2" % ("install-server", sps_version)
     virt_platform["hosts"]["router"]["disks"] = [{'size': '15Gi',
                                                   'image': img}]
+    virt_platform["hosts"]["router"]["profile"] = 'router'
+
     # adds image checksum to the router
     checksum = _get_checksum(images_url, sps_version, img)
     images_checksums[img] = checksum

--- a/common/infra-virt.function
+++ b/common/infra-virt.function
@@ -23,7 +23,6 @@ set -ue
 
 PREFIX=${PREFIX:-${USER}}
 
-router_name="router"
 routerip=""
 installserverip=""
 virthost="localhost"
@@ -186,7 +185,8 @@ snapshot_exists() {
     return 0
 }
 
-find_install_server() {
+find_host_by_profile() {
+    local profile=$1
     for name in $(ssh ${SSHOPTS} root@${virthost} virsh list --all --name); do
         local vm_prefix=$(get_key_from_domain_metadata ${name} prefix)
 
@@ -194,8 +194,8 @@ find_install_server() {
             continue
         fi
 
-        local profile=$(get_key_from_domain_metadata ${name} profile)
-        if [[ $profile != "install-server" ]]; then
+        local vm_profile=$(get_key_from_domain_metadata ${name} profile)
+        if [[ $vm_profile != ${profile} ]]; then
             continue
         fi
 
@@ -229,11 +229,9 @@ deploy() {
     $ORIG/virtualizor.py ${ctdir}/${platform} ${virthost} --prefix ${PREFIX} --public_network nat ${virtualizor_extra_args}
     rm ${tmp_ssh_pub_key}
 
-    local installserver_name=$(find_install_server)
+    local installserver_name=$(find_host_by_profile 'install-server')
     local mac=$(get_mac ${installserver_name})
     installserverip=$(get_ip ${mac})
-    local mac=$(get_mac ${router_name})
-    routerip=$(get_ip ${mac})
 
     local retry=0
     while ! rsync -e "ssh $SSHOPTS" --quiet -av --no-owner --no-group ${ctdir}/top/ root@$installserverip:/; do
@@ -302,7 +300,7 @@ call_jenkins_job() {
     # e.g: puppet, upgrade, sanity
     local jenkins_job_name=$1
 
-    local installserver_name=$(find_install_server)
+    local installserver_name=$(find_host_by_profile 'install-server')
     local mac=$(get_mac ${installserver_name})
     installserverip=$(get_ip ${mac})
 
@@ -331,14 +329,18 @@ call_jenkins_job() {
 
     kill ${tail_job}
     if ! [ -z ${socks+x} ]; then
-        create_socks ${routerip}
+        create_socks
     fi
 
 }
 
 create_socks() {
     local port=1080
-    routerip=$1
+
+    local router_name=$(find_host_by_profile 'router')
+    local mac=$(get_mac ${router_name})
+    local routerip=$(get_ip ${mac})
+
     portlist=$(ssh ${SSHOPTS} root@${virthost} netstat -lntp | awk '{print $4}' | awk -F':' '{print $NF}' | grep 108.)
     while [ "${portlist}x" != "x" ] ; do
         if [ $(echo ${portlist} | grep ${port} | wc -l) -eq 1 ]; then

--- a/common/infra-virt.function
+++ b/common/infra-virt.function
@@ -22,7 +22,6 @@
 set -ue
 
 PREFIX=${PREFIX:-${USER}}
-installserver_name=${installserver_name:-"os-ci-test4"}
 
 router_name="router"
 routerip=""
@@ -90,6 +89,7 @@ upgrade_to() {
     local ctdir=$1
     shift
 
+    local installserver_name=$(find_host_by_profile 'install-server')
     drop_hosts ${installserver_name} router
     deploy ${ctdir}
     call_jenkins_job "upgrade"
@@ -113,6 +113,7 @@ snapshot_create() {
 snapshot_restore() {
     local name=$1
 
+    local installserver_name=$(find_host_by_profile 'install-server')
     local mac=$(get_mac ${installserver_name})
     installserverip=$(get_ip ${mac})
 
@@ -185,6 +186,24 @@ snapshot_exists() {
     return 0
 }
 
+find_install_server() {
+    for name in $(ssh ${SSHOPTS} root@${virthost} virsh list --all --name); do
+        local vm_prefix=$(get_key_from_domain_metadata ${name} prefix)
+
+        if [[ $vm_prefix != $PREFIX ]]; then
+            continue
+        fi
+
+        local profile=$(get_key_from_domain_metadata ${name} profile)
+        if [[ $profile != "install-server" ]]; then
+            continue
+        fi
+
+        echo $(get_key_from_domain_metadata ${name} hostname)
+        break
+    done
+}
+
 deploy() {
     local ctdir=$1
     shift
@@ -209,6 +228,8 @@ deploy() {
 
     $ORIG/virtualizor.py ${ctdir}/${platform} ${virthost} --prefix ${PREFIX} --public_network nat ${virtualizor_extra_args}
     rm ${tmp_ssh_pub_key}
+
+    local installserver_name=$(find_install_server)
     local mac=$(get_mac ${installserver_name})
     installserverip=$(get_ip ${mac})
     local mac=$(get_mac ${router_name})
@@ -281,6 +302,7 @@ call_jenkins_job() {
     # e.g: puppet, upgrade, sanity
     local jenkins_job_name=$1
 
+    local installserver_name=$(find_install_server)
     local mac=$(get_mac ${installserver_name})
     installserverip=$(get_ip ${mac})
 
@@ -330,4 +352,11 @@ create_socks() {
     done
     ssh -f -N -D 0.0.0.0:${port} ${routerip}
     echo "Port ${port} for the server socks"
+}
+
+get_key_from_domain_metadata() {
+    local name=$1
+    local key=$2
+    value=$(ssh ${SSHOPTS} root@${virthost} virsh metadata ${name} http://virtualizor/instance 2>/dev/null|xmllint --xpath "string(/instance/${key})" - 2>/dev/null)
+    echo ${value}
 }

--- a/templates/host.py
+++ b/templates/host.py
@@ -27,6 +27,12 @@ HOST = """
     <type arch='x86_64' machine='pc'>hvm</type>
     <bios useserial='yes' rebootTimeout='5000'/>
   </os>
+  <metadata>
+    <virtualizor:instance
+     xmlns:virtualizor="http://virtualizor/instance">
+      <virtualizor:profile>{{ profile }}</virtualizor:profile>
+    </virtualizor:instance>
+  </metadata>
   <sysinfo type='smbios'>
     <bios>
       <entry name='vendor'>eNovance</entry>

--- a/templates/host.py
+++ b/templates/host.py
@@ -31,6 +31,8 @@ HOST = """
     <virtualizor:instance
      xmlns:virtualizor="http://virtualizor/instance">
       <virtualizor:profile>{{ profile }}</virtualizor:profile>
+      <virtualizor:prefix>{{ prefix }}</virtualizor:prefix>
+      <virtualizor:hostname>{{ hostname }}</virtualizor:hostname>
     </virtualizor:instance>
   </metadata>
   <sysinfo type='smbios'>

--- a/virt_platform_pxe.yml.sample
+++ b/virt_platform_pxe.yml.sample
@@ -68,6 +68,7 @@ hosts:
       network_name: __public_network__
     profile: install-server
   router:
+    profile: router
     disks:
     - image: install-server-D7-I.1.3.0.img.qcow2
       size: 15Gi

--- a/virt_platform_qcow2.yml.sample
+++ b/virt_platform_qcow2.yml.sample
@@ -71,6 +71,7 @@ hosts:
       network_name: __public_network__
     profile: install-server
   router:
+    profile: router
     disks:
     - image: install-server-D7-I.1.3.0.img.qcow2
       size: 15Gi

--- a/virtualizor.py
+++ b/virtualizor.py
@@ -210,7 +210,10 @@ class Host(object):
                      'emulator': self.hypervisor.emulator,
                      'memory': 8 * 1024 ** 2,
                      'ncpus': 2,
-                     'cpus': [], 'disks': [], 'nics': []}
+                     'cpus': [],
+                     'disks': [],
+                     'nics': [],
+                     'prefix': conf.prefix}
         self.disk_cpt = 0
 
         for k in ('uuid', 'serial', 'product_name',

--- a/virtualizor.py
+++ b/virtualizor.py
@@ -214,7 +214,7 @@ class Host(object):
         self.disk_cpt = 0
 
         for k in ('uuid', 'serial', 'product_name',
-                  'memory', 'ncpus'):
+                  'memory', 'ncpus', 'profile'):
             if k not in host_definition:
                 continue
             self.meta[k] = host_definition[k]


### PR DESCRIPTION
We now inject some meta information in the libvirt domain. We use them to identify the
 install-server and the router machines. This way we can remove the static global
variables `installserver_name` and `router_name`.
