### PR TITLE
collectory.py: exit(1) if now gateway

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -61,6 +61,8 @@ def _get_router_nic(config_path):
                         "name": "eth0",
                         "netmask": host["netmask"],
                         "network": str(net)}
+    print("Error: Cannot find a gateway in the .cmdb files.")
+    sys.exit(1)
 
 
 def _get_checksum(images_url, sps_version, img):


### PR DESCRIPTION
exit(1) with an error message if _get_router_nic() failed to find a
gateway configuration in the cmdb files.
