### PR TITLE
virtualizor.py: fallback mode to get the VM IP on older libvirt

### DIFF
--- a/virtualizor.py
+++ b/virtualizor.py
@@ -279,7 +279,7 @@ class Host(object):
                     'name': 'root',
                     'ssh-authorized-keys': ssh_keys
                 }
-                  ],
+            ],
             'write_files': [
                 {
                     'path': '/etc/resolv.conf',


### PR DESCRIPTION
On RHEL 7, the Python bindings for libvirt do not have the 'DHCPLeases' method.
This commits restore the previous method to get a VM IP if the method is not present.
