### PR TITLE
[doc] Add missing package in the list iptables-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We use a Fedora 21 with the following extra packages:
 - libvirt
 - mtools
 - qemu-kvm
+- iptables-services
 
 You will need to disable firewalld and enable libvirt:
 


### PR DESCRIPTION
With my Fedora 21 I need also `iptables-services` for the following part : 

```
sudo service iptables save
....
```

My2cents,
Gaël
