### PR TITLE
[Doc] typo : virt-infra is now infra-virt

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ It generates a directory 'top/' in the current directory.
 
 ```sh
 $ cd ~
-$ git clone https://github.com/enovance/virt-infra.git
-$ cd virt-infra/
+$ git clone https://github.com/enovance/infra-virt.git
+$ cd infra-virt/
 $ ./collector.py --config-dir ~/config-tools/top/etc --sps-version D7-I.1.3.0
 Virtual platform generated successfully at 'virt_platform.yml' !
 ```
@@ -133,7 +133,7 @@ It will generate a file 'virt_platform.yml' which describe the corresponding vir
 platform. You may take a look at a sample in the virtualization directory.
 
 ```sh
-$ cd ~/virt-infra/
+$ cd ~/infra-virt/
 $ ./virtualizor.py virt_platform.yml my-hypervisor-node --replace --pub-key-file ~/.ssh/boa.pub
 ```
 


### PR DESCRIPTION
Update only readme.md
