### PR TITLE
Update the default timeout value

### DIFF
--- a/common/infra-virt.function
+++ b/common/infra-virt.function
@@ -31,7 +31,7 @@ tempest=""
 logs=""
 
 # Default values if not set by user env
-TIMEOUT_ITERATION=${TIMEOUT_ITERATION:-"300"}
+TIMEOUT_ITERATION=${TIMEOUT_ITERATION:-"600"}
 LOG_DIR=${LOG_DIR:-"$(pwd)/logs"}
 [ -d ${LOG_DIR} ] || mkdir -p ${LOG_DIR}
 


### PR DESCRIPTION
When we enable EDD and Selinux it take more than 300s to install in PXE.
600 is enough to avoid timeout on big plateform with EDD and SeLinux
